### PR TITLE
test(e2e): cover previously-untested CLI commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Download Alby Hub binary
         run: |
-          curl -sL https://github.com/getAlby/hub/releases/download/v1.21.4/albyhub-Server-Linux-x86_64.tar.bz2 \
+          curl -sL https://github.com/getAlby/hub/releases/download/v1.23.0/albyhub-Server-Linux-x86_64.tar.bz2 \
             -o src/test/e2e/albyhub-Server-Linux-x86_64.tar.bz2
           mkdir -p src/test/e2e/albyhub-Server-Linux-x86_64
           tar -xjf src/test/e2e/albyhub-Server-Linux-x86_64.tar.bz2 -C src/test/e2e/albyhub-Server-Linux-x86_64

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "dev": "yarn build && node build/index.js",
     "test": "yarn build && vitest run --config vitest.config.ts",
     "test:e2e": "yarn build && vitest run --config vitest.config.e2e.ts",
+    "test:e2e:standalone": "yarn build && vitest run --config vitest.config.e2e-standalone.ts",
     "test:watch": "vitest"
   },
   "keywords": [

--- a/src/test/e2e/README.md
+++ b/src/test/e2e/README.md
@@ -12,10 +12,10 @@ Download the Linux server build from the [Alby Hub GitHub releases](https://gith
 src/test/e2e/albyhub-Server-Linux-x86_64/
 ```
 
-For example, for `v1.22.2`:
+For example, for `v1.23.0`:
 
 ```bash
-curl -L https://github.com/getAlby/hub/releases/download/v1.22.2/albyhub-Server-Linux-x86_64.tar.bz2 \
+curl -L https://github.com/getAlby/hub/releases/download/v1.23.0/albyhub-Server-Linux-x86_64.tar.bz2 \
   -o src/test/e2e/albyhub-Server-Linux-x86_64.tar.bz2
 mkdir -p src/test/e2e/albyhub-Server-Linux-x86_64
 tar -xjf src/test/e2e/albyhub-Server-Linux-x86_64.tar.bz2 -C src/test/e2e/albyhub-Server-Linux-x86_64

--- a/src/test/e2e/README.md
+++ b/src/test/e2e/README.md
@@ -6,25 +6,67 @@ End-to-end tests that spawn a real Alby Hub binary and exercise the CLI against 
 
 ### Alby Hub binary
 
-Download the Linux Ubuntu 24.04 desktop build from the [Alby Hub GitHub releases](https://github.com/getAlby/hub/releases), extract it, and place it at:
+Download the Linux server build from the [Alby Hub GitHub releases](https://github.com/getAlby/hub/releases), extract it, and place it at:
 
 ```
 src/test/e2e/albyhub-Server-Linux-x86_64/
+```
+
+For example, for `v1.22.2`:
+
+```bash
+curl -L https://github.com/getAlby/hub/releases/download/v1.22.2/albyhub-Server-Linux-x86_64.tar.bz2 \
+  -o src/test/e2e/albyhub-Server-Linux-x86_64.tar.bz2
+mkdir -p src/test/e2e/albyhub-Server-Linux-x86_64
+tar -xjf src/test/e2e/albyhub-Server-Linux-x86_64.tar.bz2 -C src/test/e2e/albyhub-Server-Linux-x86_64
 ```
 
 The directory must contain at minimum:
 - `bin/albyhub` — the executable
 - `lib/libldk_node.so` — the LDK node shared library
 
-### Polar (regtest channel lifecycle tests)
+### Bitcoin Core regtest node (required by every suite)
 
-The `channel-lifecycle.e2e.test.ts` suite requires a local Bitcoin Core node accessible via RPC.
+Every suite starts the hub's LDK node, which needs a Bitcoin Core RPC backend to
+reach `running` — without one the hub never finishes starting and the tests time
+out. The tests connect to `127.0.0.1:18443` with the Polar default credentials
+(`polaruser` / `polarpass`), so any of the following works:
+
+**Option A — Polar (GUI):**
 
 1. Download [Polar](https://lightningpolar.com/)
 2. Create a network with a Bitcoin Core node using the default credentials (`polaruser` / `polarpass`)
 3. Start the network
 
-The tests connect to Bitcoin Core on `127.0.0.1:18443` using those defaults — no extra env vars needed.
+**Option B — headless `bitcoind` (no GUI, what CI uses):**
+
+```bash
+# Download Bitcoin Core (any recent version; CI uses 28.1)
+curl -L https://bitcoincore.org/bin/bitcoin-core-28.1/bitcoin-28.1-x86_64-linux-gnu.tar.gz \
+  -o /tmp/bitcoin-28.1.tar.gz
+tar -xzf /tmp/bitcoin-28.1.tar.gz -C /tmp
+
+# Configure a regtest node with the Polar default credentials
+mkdir -p /tmp/bitcoin-regtest
+cat > /tmp/bitcoin-regtest/bitcoin.conf <<'EOF'
+regtest=1
+server=1
+rpcuser=polaruser
+rpcpassword=polarpass
+fallbackfee=0.0002
+[regtest]
+rpcbind=127.0.0.1
+rpcport=18443
+rpcallowip=127.0.0.1
+EOF
+
+# Start it (runs in the background)
+/tmp/bitcoin-28.1/bin/bitcoind -datadir=/tmp/bitcoin-regtest -daemon
+```
+
+The `channel-lifecycle.e2e.test.ts` and `make-offer.e2e.test.ts` suites additionally
+mine blocks and fund the hub over this same RPC connection (no extra setup needed —
+the tests do it themselves).
 
 ### Mutinynet NWC URL (Mutinynet LSP test)
 
@@ -41,8 +83,13 @@ Without this file (or with the variable unset) the Mutinynet tests are skipped a
 ## Running
 
 ```bash
-# All E2E tests
+# All E2E tests (needs bitcoind regtest; channel suites need nothing more,
+# Mutinynet suites self-skip without MUTINYNET_NWC_URL)
 yarn test:e2e
+
+# Every suite except the Mutinynet ones (which need MUTINYNET_NWC_URL) —
+# i.e. everything that runs against a hub binary + bitcoind regtest
+yarn test:e2e:standalone
 
 # Individual suite (vitest pattern matching)
 yarn test:e2e --reporter=verbose
@@ -50,14 +97,31 @@ yarn test:e2e --reporter=verbose
 
 ## Test suites
 
+In the "Requires" column, **bitcoind** means a regtest Bitcoin Core node as
+described above (Polar or headless). It is needed by every suite.
+
 | File | Requires | Description |
 |------|----------|-------------|
-| `setup.e2e.test.ts` | Hub binary | Hub initialisation |
-| `start.e2e.test.ts` | Hub binary | Node start + JWT |
-| `unlock.e2e.test.ts` | Hub binary | Token refresh |
-| `stop.e2e.test.ts` | Hub binary | Node stop |
-| `channel-lifecycle.e2e.test.ts` | Hub binary + Polar | Two-hub regtest channel open, payments, close |
+| `setup.e2e.test.ts` | Hub binary + bitcoind | Hub initialisation |
+| `start.e2e.test.ts` | Hub binary + bitcoind | Node start + JWT |
+| `unlock.e2e.test.ts` | Hub binary + bitcoind | Token refresh |
+| `stop.e2e.test.ts` | Hub binary + bitcoind | Node stop |
+| `sync.e2e.test.ts` | Hub binary + bitcoind | Queue a wallet sync |
+| `change-password.e2e.test.ts` | Hub binary + bitcoind | Change unlock password |
+| `backup-mnemonic.e2e.test.ts` | Hub binary + bitcoind | Export recovery phrase |
+| `get-info.e2e.test.ts` | Hub binary + bitcoind | Hub status / version / config |
+| `list-apps.e2e.test.ts` | Hub binary + bitcoind | List NWC app connections |
+| `create-app.e2e.test.ts` | Hub binary + bitcoind | Create NWC app (default, scoped/budgeted, isolated) |
+| `lookup-transaction.e2e.test.ts` | Hub binary + bitcoind | Look up an invoice by payment hash + not-found error |
+| `connect-alby-account.e2e.test.ts` | Hub binary + bitcoind | Returns auth URL when no account is linked |
+| `request-alby-lsp-channel-offer.e2e.test.ts` | Hub binary + bitcoind | Errors when no Alby account is linked |
+| `get-channel-suggestions.e2e.test.ts` | Hub binary + bitcoind | List available LSP providers |
+| `channel-lifecycle.e2e.test.ts` | Hub binary + bitcoind (+ mining) | Two-hub regtest channel open, payments, close |
+| `make-offer.e2e.test.ts` | Hub binary + bitcoind (+ mining) | BOLT-12 offer over a funded channel |
 | `mutinynet-lsp.e2e.test.ts` | Hub binary + `MUTINYNET_NWC_URL` | Signet LSP channel open via NWC payment, payments, close |
+
+The `standalone` config (`yarn test:e2e:standalone`) runs every suite above
+**except** the Mutinynet suites (which need `MUTINYNET_NWC_URL`).
 
 ## Notes
 

--- a/src/test/e2e/change-password.e2e.test.ts
+++ b/src/test/e2e/change-password.e2e.test.ts
@@ -6,6 +6,7 @@ import {
   runCommand,
   waitForInfo,
   killHub,
+  expectValidJwt,
 } from "./helpers";
 
 const HUB_PORT = 18088;
@@ -76,7 +77,6 @@ test(
     ]);
     expect(result.status).toBe(1);
     const out = JSON.parse(result.stdout);
-    expect(typeof out.error).toBe("string");
     expect(out.error).toEqual("Current password and confirmation do not match");
   },
 );
@@ -141,7 +141,7 @@ test(
     ]);
     expect(newStart.status).toBe(0);
     const newStartOut = JSON.parse(newStart.stdout);
-    expect(typeof newStartOut.token).toBe("string");
+    expectValidJwt(newStartOut.token);
 
     // avoid rate limit
     await new Promise((r) => setTimeout(r, 3000));
@@ -169,6 +169,6 @@ test(
     ]);
     expect(newUnlock.status).toBe(0);
     const newOut = JSON.parse(newUnlock.stdout);
-    expect(typeof newOut.token).toBe("string");
+    expectValidJwt(newOut.token);
   },
 );

--- a/src/test/e2e/channel-lifecycle.e2e.test.ts
+++ b/src/test/e2e/channel-lifecycle.e2e.test.ts
@@ -130,8 +130,8 @@ test("deposits on-chain funds to hub A", { timeout: 120_000 }, async () => {
   ]);
   expect(addrResult.status).toBe(0);
   const { address } = JSON.parse(addrResult.stdout);
-  expect(typeof address).toBe("string");
-  expect(address.length).toBeGreaterThan(0);
+  // regtest on-chain addresses are native segwit with the "bcrt1" HRP
+  expect(address).toMatch(/^bcrt1[0-9a-z]+$/);
 
   await bitcoinRpc("sendtoaddress", [address, 0.1]);
 
@@ -249,8 +249,8 @@ test("opens channel from hub A to hub B", { timeout: 120_000 }, async () => {
   ]);
   expect(openResult.status).toBe(0);
   const openOutput = JSON.parse(openResult.stdout);
-  expect(typeof openOutput.fundingTxId).toBe("string");
-  expect(openOutput.fundingTxId.length).toBeGreaterThan(0);
+  // funding tx id is a bitcoin txid (32 bytes, 64 lowercase hex chars)
+  expect(openOutput.fundingTxId).toMatch(/^[0-9a-f]{64}$/);
 
   await bitcoinRpc("generatetoaddress", [6, miningAddr]);
 
@@ -285,11 +285,11 @@ test("opens channel from hub A to hub B", { timeout: 120_000 }, async () => {
   ]);
   expect(listChAResult.status).toBe(0);
   const listChA = JSON.parse(listChAResult.stdout) as Channel[];
-  expect(Array.isArray(listChA)).toBe(true);
   const activeChA = listChA.find(
     (c) => c.remotePubkey === hubBConnInfo.pubkey && c.active,
   );
   expect(activeChA).toBeDefined();
+  expect(activeChA!.fundingTxId).toBe(openOutput.fundingTxId);
 
   // Hub B: list-channels via CLI and verify at least one active channel
   const listChBResult = runCommand([
@@ -301,7 +301,6 @@ test("opens channel from hub A to hub B", { timeout: 120_000 }, async () => {
   ]);
   expect(listChBResult.status).toBe(0);
   const listChB = JSON.parse(listChBResult.stdout) as Channel[];
-  expect(Array.isArray(listChB)).toBe(true);
   expect(listChB.some((c) => c.active)).toBe(true);
 
   // Hub A: get-health post-channel
@@ -334,7 +333,8 @@ test("sends sats from hub A to hub B", { timeout: 120_000 }, async () => {
   ]);
   expect(invoiceResult.status).toBe(0);
   const invoiceData = JSON.parse(invoiceResult.stdout) as { invoice: string };
-  expect(typeof invoiceData.invoice).toBe("string");
+  // regtest BOLT-11 invoices use the "lnbcrt" human-readable prefix
+  expect(invoiceData.invoice).toMatch(/^lnbcrt[0-9a-z]+$/);
 
   // Record Hub A's balance before payment
   const balancesBeforeResult = runCommand([
@@ -412,7 +412,8 @@ test("sends sats from hub B back to hub A", { timeout: 120_000 }, async () => {
   ]);
   expect(invoiceResult.status).toBe(0);
   const invoiceData = JSON.parse(invoiceResult.stdout) as { invoice: string };
-  expect(typeof invoiceData.invoice).toBe("string");
+  // regtest BOLT-11 invoices use the "lnbcrt" human-readable prefix
+  expect(invoiceData.invoice).toMatch(/^lnbcrt[0-9a-z]+$/);
 
   // Record Hub A's balance before payment
   const hubABalancesBeforeResult = runCommand([

--- a/src/test/e2e/connect-alby-account.e2e.test.ts
+++ b/src/test/e2e/connect-alby-account.e2e.test.ts
@@ -1,0 +1,66 @@
+import { test, expect, beforeAll, afterAll } from "vitest";
+import type { ChildProcess } from "node:child_process";
+import {
+  TEST_PASSWORD,
+  spawnHub,
+  runCommand,
+  waitForInfo,
+  killHub,
+} from "./helpers";
+
+const HUB_PORT = 18097;
+const HUB_URL = `http://localhost:${HUB_PORT}`;
+
+let hubProcess: ChildProcess;
+let token: string;
+
+beforeAll(async () => {
+  ({ hubProcess } = await spawnHub(HUB_PORT, "hub-cli-e2e-connectalby-"));
+
+  const setup = runCommand([
+    "--url",
+    HUB_URL,
+    "setup",
+    "--password",
+    TEST_PASSWORD,
+    "--backend",
+    "LDK",
+  ]);
+  if (setup.status !== 0) throw new Error(`setup failed: ${setup.stderr}`);
+
+  const start = runCommand([
+    "--url",
+    HUB_URL,
+    "start",
+    "--password",
+    TEST_PASSWORD,
+  ]);
+  if (start.status !== 0) throw new Error(`start failed: ${start.stderr}`);
+  token = JSON.parse(start.stdout).token;
+
+  await waitForInfo(HUB_URL, (i) => i.running);
+}, 120_000);
+
+afterAll(async () => {
+  if (hubProcess) await killHub(hubProcess);
+});
+
+test("connect-alby-account (no code) returns an auth URL when unconnected", () => {
+  const result = runCommand([
+    "--url",
+    HUB_URL,
+    "--token",
+    token,
+    "connect-alby-account",
+  ]);
+  expect(result.status).toBe(0);
+  const out = JSON.parse(result.stdout) as {
+    albyAuthUrl?: string;
+    message?: string;
+    albyAccountConnected?: boolean;
+  };
+  // Hub has no linked account, so we expect the "not connected" branch.
+  expect(out.albyAccountConnected).toBeUndefined();
+  expect(typeof out.message).toBe("string");
+  expect(typeof out.albyAuthUrl).toBe("string");
+});

--- a/src/test/e2e/connect-alby-account.e2e.test.ts
+++ b/src/test/e2e/connect-alby-account.e2e.test.ts
@@ -61,6 +61,12 @@ test("connect-alby-account (no code) returns an auth URL when unconnected", () =
   };
   // Hub has no linked account, so we expect the "not connected" branch.
   expect(out.albyAccountConnected).toBeUndefined();
-  expect(typeof out.message).toBe("string");
-  expect(typeof out.albyAuthUrl).toBe("string");
+  // the auth URL is the Alby OAuth authorize endpoint; client_id varies, so
+  // assert the stable parts of the URL rather than the whole string
+  expect(out.albyAuthUrl).toMatch(/^https:\/\/getalby\.com\/oauth\?/);
+  expect(out.albyAuthUrl).toContain("response_type=code");
+  expect(out.albyAuthUrl).toContain("client_id=");
+  // the message tells the user to open that URL and re-run with --code
+  expect(out.message).toContain("albyAuthUrl");
+  expect(out.message).toContain("--code");
 });

--- a/src/test/e2e/create-app.e2e.test.ts
+++ b/src/test/e2e/create-app.e2e.test.ts
@@ -1,0 +1,132 @@
+import { test, expect, beforeAll, afterAll } from "vitest";
+import type { ChildProcess } from "node:child_process";
+import {
+  TEST_PASSWORD,
+  spawnHub,
+  runCommand,
+  waitForInfo,
+  killHub,
+} from "./helpers";
+import type { ListAppsResponse, CreateAppResponse } from "../../types.js";
+
+const HUB_PORT = 18095;
+const HUB_URL = `http://localhost:${HUB_PORT}`;
+
+let hubProcess: ChildProcess;
+let token: string;
+
+beforeAll(async () => {
+  ({ hubProcess } = await spawnHub(HUB_PORT, "hub-cli-e2e-createapp-"));
+
+  const setup = runCommand([
+    "--url",
+    HUB_URL,
+    "setup",
+    "--password",
+    TEST_PASSWORD,
+    "--backend",
+    "LDK",
+  ]);
+  if (setup.status !== 0) throw new Error(`setup failed: ${setup.stderr}`);
+
+  const start = runCommand([
+    "--url",
+    HUB_URL,
+    "start",
+    "--password",
+    TEST_PASSWORD,
+  ]);
+  if (start.status !== 0) throw new Error(`start failed: ${start.stderr}`);
+  token = JSON.parse(start.stdout).token;
+
+  await waitForInfo(HUB_URL, (i) => i.running);
+}, 120_000);
+
+afterAll(async () => {
+  if (hubProcess) await killHub(hubProcess);
+});
+
+test("create-app creates a connection that then appears in list-apps", () => {
+  const appName = "e2e-default-app";
+  const create = runCommand([
+    "--url",
+    HUB_URL,
+    "--token",
+    token,
+    "create-app",
+    "--name",
+    appName,
+  ]);
+  expect(create.status).toBe(0);
+  const app = JSON.parse(create.stdout) as CreateAppResponse;
+  expect(app.name).toBe(appName);
+  expect(typeof app.id).toBe("number");
+  expect(app.pairingUri.startsWith("nostr+walletconnect://")).toBe(true);
+  expect(typeof app.walletPubkey).toBe("string");
+
+  const list = runCommand(["--url", HUB_URL, "--token", token, "list-apps"]);
+  expect(list.status).toBe(0);
+  const out = JSON.parse(list.stdout) as ListAppsResponse;
+  const created = out.apps.find((a) => a.id === app.id);
+  expect(created).toBeDefined();
+  expect(created?.name).toBe(appName);
+});
+
+test("create-app honours custom scopes, max-amount and budget renewal", () => {
+  const appName = "e2e-scoped-app";
+  const create = runCommand([
+    "--url",
+    HUB_URL,
+    "--token",
+    token,
+    "create-app",
+    "--name",
+    appName,
+    // maxAmount/budgetRenewal are only stored against the pay_invoice scope
+    // (see hub api/api.go: the response reads them from the pay_invoice
+    // permission only), so this scope set must include pay_invoice.
+    "--scopes",
+    "pay_invoice,get_balance",
+    "--max-amount",
+    "5000",
+    "--budget-renewal",
+    "weekly",
+  ]);
+  expect(create.status).toBe(0);
+  const app = JSON.parse(create.stdout) as CreateAppResponse;
+
+  const list = runCommand(["--url", HUB_URL, "--token", token, "list-apps"]);
+  const out = JSON.parse(list.stdout) as ListAppsResponse;
+  const created = out.apps.find((a) => a.id === app.id);
+  expect(created).toBeDefined();
+  expect(created?.maxAmount).toBe(5000);
+  expect(created?.budgetRenewal).toBe("weekly");
+  expect([...(created?.scopes ?? [])].sort()).toEqual(
+    ["pay_invoice", "get_balance"].sort(),
+  );
+  expect(created?.isolated).toBe(false);
+});
+
+test("create-app can create an isolated sub-wallet app", () => {
+  const appName = "e2e-isolated-app";
+  const create = runCommand([
+    "--url",
+    HUB_URL,
+    "--token",
+    token,
+    "create-app",
+    "--name",
+    appName,
+    "--isolated",
+    "--unlock-password",
+    TEST_PASSWORD,
+  ]);
+  expect(create.status).toBe(0);
+  const app = JSON.parse(create.stdout) as CreateAppResponse;
+
+  const list = runCommand(["--url", HUB_URL, "--token", token, "list-apps"]);
+  const out = JSON.parse(list.stdout) as ListAppsResponse;
+  const created = out.apps.find((a) => a.id === app.id);
+  expect(created).toBeDefined();
+  expect(created?.isolated).toBe(true);
+});

--- a/src/test/e2e/create-app.e2e.test.ts
+++ b/src/test/e2e/create-app.e2e.test.ts
@@ -60,9 +60,15 @@ test("create-app creates a connection that then appears in list-apps", () => {
   expect(create.status).toBe(0);
   const app = JSON.parse(create.stdout) as CreateAppResponse;
   expect(app.name).toBe(appName);
-  expect(typeof app.id).toBe("number");
-  expect(app.pairingUri.startsWith("nostr+walletconnect://")).toBe(true);
-  expect(typeof app.walletPubkey).toBe("string");
+  expect(app.id).toBeGreaterThan(0);
+  // walletPubkey is a 32-byte nostr key (64 lowercase hex chars)
+  expect(app.walletPubkey).toMatch(/^[0-9a-f]{64}$/);
+  // the pairing URI is the NWC connection string keyed on that wallet pubkey
+  expect(app.pairingUri).toContain(
+    `nostr+walletconnect://${app.walletPubkey}?`,
+  );
+  expect(app.pairingUri).toContain("relay=");
+  expect(app.pairingUri).toContain("secret=");
 
   const list = runCommand(["--url", HUB_URL, "--token", token, "list-apps"]);
   expect(list.status).toBe(0);

--- a/src/test/e2e/get-channel-suggestions.e2e.test.ts
+++ b/src/test/e2e/get-channel-suggestions.e2e.test.ts
@@ -56,5 +56,19 @@ test("get-channel-suggestions returns a list of LSP providers", () => {
   ]);
   expect(result.status).toBe(0);
   const suggestions = JSON.parse(result.stdout) as ChannelPeerSuggestion[];
-  expect(Array.isArray(suggestions)).toBe(true);
+  expect(suggestions.length).toBeGreaterThan(0);
+
+  // Megalith is a long-standing default suggestion — assert it is present and
+  // well-formed rather than just checking the value is an array.
+  const megalith = suggestions.find((s) => /megalith/i.test(s.name));
+  expect(megalith).toBeDefined();
+  // node pubkey is a 33-byte compressed secp256k1 key (66 lowercase hex chars)
+  expect(megalith!.pubkey).toMatch(/^[0-9a-f]{66}$/);
+  expect(megalith!.name).toContain("Megalith");
+
+  // every suggestion should carry a usable pubkey and payment method
+  for (const s of suggestions) {
+    expect(s.pubkey).toMatch(/^[0-9a-f]{66}$/);
+    expect(["lightning", "onchain"]).toContain(s.paymentMethod);
+  }
 });

--- a/src/test/e2e/get-channel-suggestions.e2e.test.ts
+++ b/src/test/e2e/get-channel-suggestions.e2e.test.ts
@@ -1,0 +1,60 @@
+import { test, expect, beforeAll, afterAll } from "vitest";
+import type { ChildProcess } from "node:child_process";
+import {
+  TEST_PASSWORD,
+  spawnHub,
+  runCommand,
+  waitForInfo,
+  killHub,
+} from "./helpers";
+import type { ChannelPeerSuggestion } from "../../types.js";
+
+const HUB_PORT = 18099;
+const HUB_URL = `http://localhost:${HUB_PORT}`;
+
+let hubProcess: ChildProcess;
+let token: string;
+
+beforeAll(async () => {
+  ({ hubProcess } = await spawnHub(HUB_PORT, "hub-cli-e2e-suggestions-"));
+
+  const setup = runCommand([
+    "--url",
+    HUB_URL,
+    "setup",
+    "--password",
+    TEST_PASSWORD,
+    "--backend",
+    "LDK",
+  ]);
+  if (setup.status !== 0) throw new Error(`setup failed: ${setup.stderr}`);
+
+  const start = runCommand([
+    "--url",
+    HUB_URL,
+    "start",
+    "--password",
+    TEST_PASSWORD,
+  ]);
+  if (start.status !== 0) throw new Error(`start failed: ${start.stderr}`);
+  token = JSON.parse(start.stdout).token;
+
+  await waitForInfo(HUB_URL, (i) => i.running);
+}, 120_000);
+
+afterAll(async () => {
+  if (hubProcess) await killHub(hubProcess);
+});
+
+test("get-channel-suggestions returns a list of LSP providers", () => {
+  const result = runCommand([
+    "--url",
+    HUB_URL,
+    "--token",
+    token,
+    "get-channel-suggestions",
+  ]);
+  expect(result.status).toBe(0);
+  const suggestions = JSON.parse(result.stdout) as ChannelPeerSuggestion[];
+  expect(Array.isArray(suggestions)).toBe(true);
+});

--- a/src/test/e2e/get-info.e2e.test.ts
+++ b/src/test/e2e/get-info.e2e.test.ts
@@ -1,0 +1,59 @@
+import { test, expect, beforeAll, afterAll } from "vitest";
+import type { ChildProcess } from "node:child_process";
+import {
+  TEST_PASSWORD,
+  NETWORK,
+  spawnHub,
+  runCommand,
+  waitForInfo,
+  killHub,
+} from "./helpers";
+import type { InfoResponse } from "../../types.js";
+
+const HUB_PORT = 18093;
+const HUB_URL = `http://localhost:${HUB_PORT}`;
+
+let hubProcess: ChildProcess;
+let token: string;
+
+beforeAll(async () => {
+  ({ hubProcess } = await spawnHub(HUB_PORT, "hub-cli-e2e-getinfo-"));
+
+  const setup = runCommand([
+    "--url",
+    HUB_URL,
+    "setup",
+    "--password",
+    TEST_PASSWORD,
+    "--backend",
+    "LDK",
+  ]);
+  if (setup.status !== 0) throw new Error(`setup failed: ${setup.stderr}`);
+
+  const start = runCommand([
+    "--url",
+    HUB_URL,
+    "start",
+    "--password",
+    TEST_PASSWORD,
+  ]);
+  if (start.status !== 0) throw new Error(`start failed: ${start.stderr}`);
+  token = JSON.parse(start.stdout).token;
+
+  await waitForInfo(HUB_URL, (i) => i.running);
+}, 120_000);
+
+afterAll(async () => {
+  if (hubProcess) await killHub(hubProcess);
+});
+
+test("get-info reports a running, set-up hub", () => {
+  const result = runCommand(["--url", HUB_URL, "--token", token, "get-info"]);
+  expect(result.status).toBe(0);
+  const info = JSON.parse(result.stdout) as InfoResponse;
+  expect(info.setupCompleted).toBe(true);
+  expect(info.running).toBe(true);
+  expect(info.network).toBe(NETWORK);
+  expect(info.backendType).toBe("LDK");
+  expect(typeof info.version).toBe("string");
+});

--- a/src/test/e2e/get-info.e2e.test.ts
+++ b/src/test/e2e/get-info.e2e.test.ts
@@ -55,5 +55,7 @@ test("get-info reports a running, set-up hub", () => {
   expect(info.running).toBe(true);
   expect(info.network).toBe(NETWORK);
   expect(info.backendType).toBe("LDK");
-  expect(typeof info.version).toBe("string");
+  // a released hub reports a semver tag like "v1.23.0"; dev builds may differ,
+  // so match the shape rather than pinning an exact version
+  expect(info.version).toMatch(/^v?\d+\.\d+\.\d+/);
 });

--- a/src/test/e2e/helpers.ts
+++ b/src/test/e2e/helpers.ts
@@ -3,8 +3,35 @@ import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { expect } from "vitest";
 import type { ChildProcess } from "node:child_process";
 import type { BalancesResponse, Channel, InfoResponse } from "../../types.js";
+
+/**
+ * Asserts that `token` is a structurally valid Alby Hub auth token and returns
+ * its decoded payload. Hub tokens are HS256 JWTs of the form
+ * `header.payload.signature` whose payload carries the granted permission and an
+ * expiry, e.g. `{"permission":"full","exp":1783845050}`. This checks far more
+ * than "is a non-empty string" — it verifies the JWT shape, algorithm, the
+ * granted permission and a sane expiry.
+ */
+export function expectValidJwt(
+  token: unknown,
+  permission = "full",
+): { permission: string; exp: number } {
+  expect(typeof token).toBe("string");
+  const parts = (token as string).split(".");
+  expect(parts).toHaveLength(3);
+  const header = JSON.parse(Buffer.from(parts[0], "base64url").toString("utf8"));
+  expect(header).toMatchObject({ alg: "HS256", typ: "JWT" });
+  const payload = JSON.parse(
+    Buffer.from(parts[1], "base64url").toString("utf8"),
+  );
+  expect(payload.permission).toBe(permission);
+  expect(typeof payload.exp).toBe("number");
+  expect(payload.exp).toBeGreaterThan(0);
+  return payload;
+}
 
 export const E2E_DIR = fileURLToPath(new URL(".", import.meta.url));
 export const HUB_BINARY = join(

--- a/src/test/e2e/list-apps.e2e.test.ts
+++ b/src/test/e2e/list-apps.e2e.test.ts
@@ -46,11 +46,30 @@ afterAll(async () => {
   if (hubProcess) await killHub(hubProcess);
 });
 
-test("list-apps returns an apps array and total count", () => {
+test("list-apps returns a freshly created app", () => {
+  const create = runCommand([
+    "--url",
+    HUB_URL,
+    "--token",
+    token,
+    "create-app",
+    "--name",
+    "e2e-list-apps-target",
+  ]);
+  if (create.status !== 0) throw new Error(`create-app failed: ${create.stderr}`);
+  const created = JSON.parse(create.stdout);
+
   const result = runCommand(["--url", HUB_URL, "--token", token, "list-apps"]);
   expect(result.status).toBe(0);
   const out = JSON.parse(result.stdout) as ListAppsResponse;
-  expect(Array.isArray(out.apps)).toBe(true);
-  expect(typeof out.totalCount).toBe("number");
+
+  // totalCount must agree with the returned page of apps
   expect(out.totalCount).toBe(out.apps.length);
+  expect(out.totalCount).toBeGreaterThanOrEqual(1);
+
+  // the app we just created must be present with matching identifiers
+  const app = out.apps.find((a) => a.name === "e2e-list-apps-target");
+  expect(app).toBeDefined();
+  expect(app!.id).toBe(created.id);
+  expect(app!.appPubkey).toMatch(/^[0-9a-f]{64}$/);
 });

--- a/src/test/e2e/list-apps.e2e.test.ts
+++ b/src/test/e2e/list-apps.e2e.test.ts
@@ -1,0 +1,56 @@
+import { test, expect, beforeAll, afterAll } from "vitest";
+import type { ChildProcess } from "node:child_process";
+import {
+  TEST_PASSWORD,
+  spawnHub,
+  runCommand,
+  waitForInfo,
+  killHub,
+} from "./helpers";
+import type { ListAppsResponse } from "../../types.js";
+
+const HUB_PORT = 18094;
+const HUB_URL = `http://localhost:${HUB_PORT}`;
+
+let hubProcess: ChildProcess;
+let token: string;
+
+beforeAll(async () => {
+  ({ hubProcess } = await spawnHub(HUB_PORT, "hub-cli-e2e-listapps-"));
+
+  const setup = runCommand([
+    "--url",
+    HUB_URL,
+    "setup",
+    "--password",
+    TEST_PASSWORD,
+    "--backend",
+    "LDK",
+  ]);
+  if (setup.status !== 0) throw new Error(`setup failed: ${setup.stderr}`);
+
+  const start = runCommand([
+    "--url",
+    HUB_URL,
+    "start",
+    "--password",
+    TEST_PASSWORD,
+  ]);
+  if (start.status !== 0) throw new Error(`start failed: ${start.stderr}`);
+  token = JSON.parse(start.stdout).token;
+
+  await waitForInfo(HUB_URL, (i) => i.running);
+}, 120_000);
+
+afterAll(async () => {
+  if (hubProcess) await killHub(hubProcess);
+});
+
+test("list-apps returns an apps array and total count", () => {
+  const result = runCommand(["--url", HUB_URL, "--token", token, "list-apps"]);
+  expect(result.status).toBe(0);
+  const out = JSON.parse(result.stdout) as ListAppsResponse;
+  expect(Array.isArray(out.apps)).toBe(true);
+  expect(typeof out.totalCount).toBe("number");
+  expect(out.totalCount).toBe(out.apps.length);
+});

--- a/src/test/e2e/lookup-transaction.e2e.test.ts
+++ b/src/test/e2e/lookup-transaction.e2e.test.ts
@@ -63,8 +63,8 @@ test("lookup-transaction finds an invoice created with make-invoice", () => {
   const invoice = JSON.parse(make.stdout) as Transaction & {
     amountSat: number;
   };
-  expect(typeof invoice.paymentHash).toBe("string");
-  expect(invoice.paymentHash.length).toBeGreaterThan(0);
+  // payment hash is the 32-byte SHA-256 of the preimage (64 lowercase hex)
+  expect(invoice.paymentHash).toMatch(/^[0-9a-f]{64}$/);
 
   const lookup = runCommand([
     "--url",
@@ -95,6 +95,5 @@ test("lookup-transaction errors for an unknown payment hash", () => {
   ]);
   expect(result.status).toBe(1);
   const out = JSON.parse(result.stdout);
-  expect(typeof out.error).toBe("string");
-  expect(out.error.length).toBeGreaterThan(0);
+  expect(out.error).toEqual("The transaction requested was not found");
 });

--- a/src/test/e2e/lookup-transaction.e2e.test.ts
+++ b/src/test/e2e/lookup-transaction.e2e.test.ts
@@ -1,0 +1,100 @@
+import { test, expect, beforeAll, afterAll } from "vitest";
+import type { ChildProcess } from "node:child_process";
+import {
+  TEST_PASSWORD,
+  spawnHub,
+  runCommand,
+  waitForInfo,
+  killHub,
+} from "./helpers";
+import type { Transaction } from "../../types.js";
+
+const HUB_PORT = 18096;
+const HUB_URL = `http://localhost:${HUB_PORT}`;
+
+let hubProcess: ChildProcess;
+let token: string;
+
+beforeAll(async () => {
+  ({ hubProcess } = await spawnHub(HUB_PORT, "hub-cli-e2e-lookuptx-"));
+
+  const setup = runCommand([
+    "--url",
+    HUB_URL,
+    "setup",
+    "--password",
+    TEST_PASSWORD,
+    "--backend",
+    "LDK",
+  ]);
+  if (setup.status !== 0) throw new Error(`setup failed: ${setup.stderr}`);
+
+  const start = runCommand([
+    "--url",
+    HUB_URL,
+    "start",
+    "--password",
+    TEST_PASSWORD,
+  ]);
+  if (start.status !== 0) throw new Error(`start failed: ${start.stderr}`);
+  token = JSON.parse(start.stdout).token;
+
+  await waitForInfo(HUB_URL, (i) => i.running);
+}, 120_000);
+
+afterAll(async () => {
+  if (hubProcess) await killHub(hubProcess);
+});
+
+test("lookup-transaction finds an invoice created with make-invoice", () => {
+  const description = "e2e lookup target";
+  const make = runCommand([
+    "--url",
+    HUB_URL,
+    "--token",
+    token,
+    "make-invoice",
+    "--amount",
+    "1234",
+    "--description",
+    description,
+  ]);
+  expect(make.status).toBe(0);
+  const invoice = JSON.parse(make.stdout) as Transaction & {
+    amountSat: number;
+  };
+  expect(typeof invoice.paymentHash).toBe("string");
+  expect(invoice.paymentHash.length).toBeGreaterThan(0);
+
+  const lookup = runCommand([
+    "--url",
+    HUB_URL,
+    "--token",
+    token,
+    "lookup-transaction",
+    invoice.paymentHash,
+  ]);
+  expect(lookup.status).toBe(0);
+  const tx = JSON.parse(lookup.stdout) as Transaction & { amountSat: number };
+  expect(tx.paymentHash).toBe(invoice.paymentHash);
+  expect(tx.type).toBe("incoming");
+  expect(tx.amountSat).toBe(1234);
+  expect(tx.description).toBe(description);
+  expect(tx.invoice.startsWith("ln")).toBe(true);
+});
+
+test("lookup-transaction errors for an unknown payment hash", () => {
+  const bogusHash = "0".repeat(64);
+  const result = runCommand([
+    "--url",
+    HUB_URL,
+    "--token",
+    token,
+    "lookup-transaction",
+    bogusHash,
+  ]);
+  expect(result.status).toBe(1);
+  const out = JSON.parse(result.stdout);
+  expect(typeof out.error).toBe("string");
+  expect(out.error.length).toBeGreaterThan(0);
+});

--- a/src/test/e2e/make-offer.e2e.test.ts
+++ b/src/test/e2e/make-offer.e2e.test.ts
@@ -174,6 +174,6 @@ test("make-offer returns a BOLT-12 offer string", { timeout: 30_000 }, async () 
   ]);
   expect(result.status).toBe(0);
   const offer = JSON.parse(result.stdout) as string;
-  expect(typeof offer).toBe("string");
-  expect(offer.startsWith("lno1")).toBe(true);
+  // BOLT-12 offers are bech32-style strings with the "lno1" prefix
+  expect(offer).toMatch(/^lno1[0-9a-z]+$/);
 });

--- a/src/test/e2e/make-offer.e2e.test.ts
+++ b/src/test/e2e/make-offer.e2e.test.ts
@@ -6,6 +6,7 @@ import {
   runCommand,
   killHub,
   bitcoinRpc,
+  waitForInfo,
   waitForBalances,
   waitForChannels,
 } from "./helpers";
@@ -78,6 +79,12 @@ beforeAll(async () => {
   if (startB.status !== 0)
     throw new Error(`Hub B start failed: ${startB.stderr}`);
   const tokenB = JSON.parse(startB.stdout).token;
+
+  // `start` returns as soon as the JWT is issued, but the LDK node boots
+  // asynchronously. Wait for both nodes to actually be running before issuing
+  // node commands like get-onchain-address (otherwise they race and fail).
+  await waitForInfo(HUB_A_URL, (info) => info.running);
+  await waitForInfo(HUB_B_URL, (info) => info.running);
 
   // Mine 101 blocks for coinbase maturity
   miningAddr = (await bitcoinRpc("getnewaddress")) as string;

--- a/src/test/e2e/request-alby-lsp-channel-offer.e2e.test.ts
+++ b/src/test/e2e/request-alby-lsp-channel-offer.e2e.test.ts
@@ -1,0 +1,60 @@
+import { test, expect, beforeAll, afterAll } from "vitest";
+import type { ChildProcess } from "node:child_process";
+import {
+  TEST_PASSWORD,
+  spawnHub,
+  runCommand,
+  waitForInfo,
+  killHub,
+} from "./helpers";
+
+const HUB_PORT = 18098;
+const HUB_URL = `http://localhost:${HUB_PORT}`;
+
+let hubProcess: ChildProcess;
+let token: string;
+
+beforeAll(async () => {
+  ({ hubProcess } = await spawnHub(HUB_PORT, "hub-cli-e2e-albyoffer-"));
+
+  const setup = runCommand([
+    "--url",
+    HUB_URL,
+    "setup",
+    "--password",
+    TEST_PASSWORD,
+    "--backend",
+    "LDK",
+  ]);
+  if (setup.status !== 0) throw new Error(`setup failed: ${setup.stderr}`);
+
+  const start = runCommand([
+    "--url",
+    HUB_URL,
+    "start",
+    "--password",
+    TEST_PASSWORD,
+  ]);
+  if (start.status !== 0) throw new Error(`start failed: ${start.stderr}`);
+  token = JSON.parse(start.stdout).token;
+
+  await waitForInfo(HUB_URL, (i) => i.running);
+}, 120_000);
+
+afterAll(async () => {
+  if (hubProcess) await killHub(hubProcess);
+});
+
+test("request-alby-lsp-channel-offer errors without a linked Alby account", () => {
+  const result = runCommand([
+    "--url",
+    HUB_URL,
+    "--token",
+    token,
+    "request-alby-lsp-channel-offer",
+  ]);
+  expect(result.status).toBe(1);
+  const out = JSON.parse(result.stdout);
+  expect(typeof out.error).toBe("string");
+  expect(out.error.length).toBeGreaterThan(0);
+});

--- a/src/test/e2e/request-alby-lsp-channel-offer.e2e.test.ts
+++ b/src/test/e2e/request-alby-lsp-channel-offer.e2e.test.ts
@@ -55,6 +55,9 @@ test("request-alby-lsp-channel-offer errors without a linked Alby account", () =
   ]);
   expect(result.status).toBe(1);
   const out = JSON.parse(result.stdout);
-  expect(typeof out.error).toBe("string");
-  expect(out.error.length).toBeGreaterThan(0);
+  // With no linked account the hub still tries to reach the Alby LSP endpoint
+  // and fails on the missing OAuth token, e.g.
+  // `Get "https://api.getalby.com/internal/lsp": oauth2: token expired ...`
+  expect(out.error).toContain("api.getalby.com/internal/lsp");
+  expect(out.error).toContain("oauth2");
 });

--- a/src/test/e2e/setup.e2e.test.ts
+++ b/src/test/e2e/setup.e2e.test.ts
@@ -28,7 +28,6 @@ test("cannot setup with an empty password", () => {
   ]);
   expect(result.status).toBe(1);
   const output = JSON.parse(result.stdout);
-  expect(typeof output.error).toBe("string");
   expect(output.error).toEqual(
     "Failed to setup node: no unlock password provided",
   );
@@ -123,6 +122,5 @@ test("cannot setup if node has ever been started", async () => {
   ]);
   expect(result.status).toBe(1);
   const output = JSON.parse(result.stdout);
-  expect(typeof output.error).toBe("string");
   expect(output.error).toEqual("Failed to setup node: setup already completed");
 });

--- a/src/test/e2e/setup.e2e.test.ts
+++ b/src/test/e2e/setup.e2e.test.ts
@@ -6,10 +6,9 @@ const HUB_PORT = 18080; // non-default port to avoid clashing with a real hub
 const HUB_URL = `http://localhost:${HUB_PORT}`;
 
 let hubProcess: ChildProcess;
-let workDir: string;
 
 beforeEach(async () => {
-  ({ hubProcess, workDir } = await spawnHub(HUB_PORT, "hub-cli-e2e-"));
+  ({ hubProcess } = await spawnHub(HUB_PORT, "hub-cli-e2e-"));
 });
 
 afterEach(async () => {

--- a/src/test/e2e/start.e2e.test.ts
+++ b/src/test/e2e/start.e2e.test.ts
@@ -13,10 +13,9 @@ const HUB_PORT = 18081; // different port from setup.e2e.test.ts (18080)
 const HUB_URL = `http://localhost:${HUB_PORT}`;
 
 let hubProcess: ChildProcess;
-let workDir: string;
 
 beforeEach(async () => {
-  ({ hubProcess, workDir } = await spawnHub(HUB_PORT, "hub-cli-e2e-start-"));
+  ({ hubProcess } = await spawnHub(HUB_PORT, "hub-cli-e2e-start-"));
 
   // setup is a prerequisite for all start tests
   const setup = runCommand([

--- a/src/test/e2e/start.e2e.test.ts
+++ b/src/test/e2e/start.e2e.test.ts
@@ -1,6 +1,13 @@
 import { test, expect, beforeEach, afterEach } from "vitest";
 import type { ChildProcess } from "node:child_process";
-import { TEST_PASSWORD, spawnHub, runCommand, waitForInfo, killHub } from "./helpers";
+import {
+  TEST_PASSWORD,
+  spawnHub,
+  runCommand,
+  waitForInfo,
+  killHub,
+  expectValidJwt,
+} from "./helpers";
 
 const HUB_PORT = 18081; // different port from setup.e2e.test.ts (18080)
 const HUB_URL = `http://localhost:${HUB_PORT}`;
@@ -38,7 +45,6 @@ test("cannot start with wrong unlock password", () => {
   ]);
   expect(result.status).toBe(1);
   const output = JSON.parse(result.stdout);
-  expect(typeof output.error).toBe("string");
   expect(output.error).toEqual("Invalid password");
 });
 
@@ -52,8 +58,7 @@ test("start returns a JWT token", { timeout: 60_000 }, async () => {
   ]);
   expect(result.status).toBe(0);
   const output = JSON.parse(result.stdout);
-  expect(typeof output.token).toBe("string");
-  expect(output.token.length).toBeGreaterThan(0);
+  expectValidJwt(output.token);
   const info = await waitForInfo(HUB_URL, (i) => i.running);
   expect(info.running).toBe(true);
 });
@@ -68,7 +73,6 @@ test("rate limit on start", { timeout: 60_000 }, () => {
   ]);
   expect(result.status).toBe(1);
   let output = JSON.parse(result.stdout);
-  expect(typeof output.error).toBe("string");
   expect(output.error).toEqual("Invalid password");
   result = runCommand([
     "--url",
@@ -79,7 +83,6 @@ test("rate limit on start", { timeout: 60_000 }, () => {
   ]);
   expect(result.status).toBe(1);
   output = JSON.parse(result.stdout);
-  expect(typeof output.error).toBe("string");
   expect(output.error).toEqual("rate limit exceeded");
 });
 

--- a/src/test/e2e/stop.e2e.test.ts
+++ b/src/test/e2e/stop.e2e.test.ts
@@ -12,10 +12,9 @@ const HUB_PORT = 18085;
 const HUB_URL = `http://localhost:${HUB_PORT}`;
 
 let hubProcess: ChildProcess;
-let workDir: string;
 
 beforeEach(async () => {
-  ({ hubProcess, workDir } = await spawnHub(HUB_PORT, "hub-cli-e2e-stop-"));
+  ({ hubProcess } = await spawnHub(HUB_PORT, "hub-cli-e2e-stop-"));
 
   // setup is a prerequisite for all stop tests
   const setup = runCommand([

--- a/src/test/e2e/stop.e2e.test.ts
+++ b/src/test/e2e/stop.e2e.test.ts
@@ -111,7 +111,6 @@ test("stop fails without a token", { timeout: 60_000 }, async () => {
   const stop = runCommand(["--url", HUB_URL, "stop"]);
   expect(stop.status).toBe(1);
   const output = JSON.parse(stop.stdout);
-  expect(typeof output.error).toBe("string");
   expect(output.error).toEqual("missing or malformed jwt");
 });
 
@@ -140,7 +139,6 @@ test(
     const secondStop = runCommand(["--url", HUB_URL, "--token", token, "stop"]);
     expect(secondStop.status).toBe(1);
     const output = JSON.parse(secondStop.stdout);
-    expect(typeof output.error).toBe("string");
     expect(output.error).toEqual("LNClient not started");
   },
 );

--- a/src/test/e2e/sync.e2e.test.ts
+++ b/src/test/e2e/sync.e2e.test.ts
@@ -61,5 +61,6 @@ test("sync queues a wallet sync", { timeout: 60_000 }, async () => {
   expect(result.status).toBe(0);
   const out = JSON.parse(result.stdout);
   expect(out.success).toBe(true);
-  expect(typeof out.message).toBe("string");
+  // e.g. "Wallet sync queued. May take up to a minute."
+  expect(out.message).toContain("sync queued");
 });

--- a/src/test/e2e/unlock.e2e.test.ts
+++ b/src/test/e2e/unlock.e2e.test.ts
@@ -13,10 +13,9 @@ const HUB_PORT = 18082; // different port from setup.e2e.test.ts (18080) and sta
 const HUB_URL = `http://localhost:${HUB_PORT}`;
 
 let hubProcess: ChildProcess;
-let workDir: string;
 
 beforeEach(async () => {
-  ({ hubProcess, workDir } = await spawnHub(HUB_PORT, "hub-cli-e2e-unlock-"));
+  ({ hubProcess } = await spawnHub(HUB_PORT, "hub-cli-e2e-unlock-"));
   // No setup or start — test 1 needs a fresh hub
 });
 

--- a/src/test/e2e/unlock.e2e.test.ts
+++ b/src/test/e2e/unlock.e2e.test.ts
@@ -6,6 +6,7 @@ import {
   runCommand,
   waitForInfo,
   killHub,
+  expectValidJwt,
 } from "./helpers";
 
 const HUB_PORT = 18082; // different port from setup.e2e.test.ts (18080) and start.e2e.test.ts (18081)
@@ -33,7 +34,6 @@ test("unlock fails if node is not started", () => {
   ]);
   expect(result.status).toBe(1);
   const output = JSON.parse(result.stdout);
-  expect(typeof output.error).toBe("string");
   expect(output.error).toEqual(
     "Node is not running, start it before unlocking.",
   );
@@ -74,8 +74,7 @@ test("unlock works if node is started", { timeout: 60_000 }, async () => {
   ]);
   expect(result.status).toBe(0);
   const output = JSON.parse(result.stdout);
-  expect(typeof output.token).toBe("string");
-  expect(output.token.length).toBeGreaterThan(0);
+  expectValidJwt(output.token);
 });
 
 test("rate limit on unlock", { timeout: 60_000 }, async () => {
@@ -113,7 +112,6 @@ test("rate limit on unlock", { timeout: 60_000 }, async () => {
   ]);
   expect(result.status).toBe(1);
   let output = JSON.parse(result.stdout);
-  expect(typeof output.error).toBe("string");
   expect(output.error).toEqual("Invalid password");
 
   result = runCommand([
@@ -125,6 +123,5 @@ test("rate limit on unlock", { timeout: 60_000 }, async () => {
   ]);
   expect(result.status).toBe(1);
   output = JSON.parse(result.stdout);
-  expect(typeof output.error).toBe("string");
   expect(output.error).toEqual("rate limit exceeded");
 });

--- a/src/test/e2e/unlock.e2e.test.ts
+++ b/src/test/e2e/unlock.e2e.test.ts
@@ -34,8 +34,9 @@ test("unlock fails if node is not started", () => {
   expect(result.status).toBe(1);
   const output = JSON.parse(result.stdout);
   expect(typeof output.error).toBe("string");
-  // TODO: hub should return a better error message here
-  expect(output.error).toEqual("Failed to save session: config not unlocked");
+  expect(output.error).toEqual(
+    "Node is not running, start it before unlocking.",
+  );
 });
 
 test("unlock works if node is started", { timeout: 60_000 }, async () => {

--- a/vitest.config.e2e-standalone.ts
+++ b/vitest.config.e2e-standalone.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+
+// "Standalone" E2E config: runs every E2E suite EXCEPT the Mutinynet ones,
+// which need a pre-funded Mutinynet (signet) wallet via MUTINYNET_NWC_URL.
+// Everything else needs only a hub binary + a local bitcoind regtest node
+// (Polar-compatible: polaruser/polarpass on 127.0.0.1:18443).
+//
+// Run with: yarn test:e2e:standalone
+export default defineConfig({
+  test: {
+    include: ["src/test/e2e/**/*.test.ts"],
+    exclude: ["node_modules", "src/test/e2e/mutinynet/**"],
+    testTimeout: 30_000,
+    hookTimeout: 60_000,
+    fileParallelism: false,
+  },
+});


### PR DESCRIPTION
## Summary

Adds E2E coverage for the six hub CLI commands that previously had **zero** E2E tests, plus a standalone `get-channel-suggestions` check that was previously only exercised inside the CI-skipped Mutinynet suite.

New per-command suites (one file per command, matching the existing convention, each with its own hub lifecycle + dedicated port `18093`–`18099`):

| Command | Cases |
|---|---|
| `get-info` | running/set-up hub reports correct status, network, backend, version |
| `list-apps` | apps array + totalCount contract |
| `create-app` | default app, custom scopes + max-amount + budget renewal, isolated sub-wallet |
| `lookup-transaction` | found (via `make-invoice`), unknown-hash error |
| `connect-alby-account` | no-`--code` branch returns auth URL when unconnected |
| `request-alby-lsp-channel-offer` | errors when no Alby account is linked |
| `get-channel-suggestions` | returns a list of LSP providers |

## Also in this PR

- **`vitest.config.e2e-standalone.ts` + `yarn test:e2e:standalone`** — runs every E2E suite **except** the Mutinynet ones (which need `MUTINYNET_NWC_URL`).
- **Fix stale assertion in `unlock.e2e.test.ts`** — the current hub returns the improved message `"Node is not running, start it before unlocking."` (this was the suite's own `// TODO`).
- **README** — documents a headless `bitcoind` regtest setup (no Polar GUI required) and lists the new suites.

## Notes / things to confirm

- Every E2E suite (not just these) requires a regtest **bitcoind** backend for the hub's LDK node to reach `running`; Polar is just one way to provide it — plain headless `bitcoind` works and is what CI uses.
- `create-app`'s `maxAmount`/`budgetRenewal` are only stored against the `pay_invoice` scope (confirmed in hub `api/api.go`), so that test includes `pay_invoice` — noted in a code comment.

## Test plan

Run against a hub binary + bitcoind regtest (`polaruser`/`polarpass` on `127.0.0.1:18443`):

```
yarn test:e2e:standalone
```

The seven new suites pass locally (10 tests). The full standalone run was green end-to-end against Alby Hub `v1.22.2` + Bitcoin Core `28.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded end-to-end test coverage with multiple new test suites validating core functionality
  * Enhanced test assertions for stricter validation of responses and identifiers
  * Introduced helper utilities for JWT token validation

* **Documentation**
  * Updated end-to-end test setup instructions with clearer prerequisites and execution examples

* **Chores**
  * Updated dependency versions for test infrastructure
  * Added new test configuration and execution scripts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->