### PR TITLE
Hint that the hub may not be running on fetch failure

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -18,8 +18,24 @@ export class HubClient {
     return h;
   }
 
+  private async fetch(path: string, init: RequestInit): Promise<Response> {
+    try {
+      return await fetch(`${this.baseUrl}${path}`, init);
+    } catch (error) {
+      // Node's fetch throws a TypeError with message "fetch failed" when it
+      // can't reach the server at all (connection refused, DNS, etc.). Only in
+      // that case do we add the hint; other errors are rethrown unchanged.
+      if (error instanceof TypeError && error.message === "fetch failed") {
+        throw new Error(
+          `${error.message} - are you sure the hub is running on ${this.baseUrl}?`,
+        );
+      }
+      throw error;
+    }
+  }
+
   async get<T>(path: string): Promise<T> {
-    const res = await fetch(`${this.baseUrl}${path}`, {
+    const res = await this.fetch(path, {
       method: "GET",
       headers: this.headers(),
     });
@@ -27,7 +43,7 @@ export class HubClient {
   }
 
   async post<T>(path: string, body?: unknown): Promise<T> {
-    const res = await fetch(`${this.baseUrl}${path}`, {
+    const res = await this.fetch(path, {
       method: "POST",
       headers: this.headers(),
       body: body !== undefined ? JSON.stringify(body) : undefined,
@@ -36,7 +52,7 @@ export class HubClient {
   }
 
   async patch<T>(path: string, body?: unknown): Promise<T> {
-    const res = await fetch(`${this.baseUrl}${path}`, {
+    const res = await this.fetch(path, {
       method: "PATCH",
       headers: this.headers(),
       body: body !== undefined ? JSON.stringify(body) : undefined,
@@ -45,7 +61,7 @@ export class HubClient {
   }
 
   async delete<T>(path: string): Promise<T> {
-    const res = await fetch(`${this.baseUrl}${path}`, {
+    const res = await this.fetch(path, {
       method: "DELETE",
       headers: this.headers(),
     });

--- a/src/test/hub.test.ts
+++ b/src/test/hub.test.ts
@@ -13,3 +13,13 @@ test("shows help when run with no arguments", () => {
   expect(output).toContain("balances");
   expect(output).toContain("channels");
 });
+
+test("hints that the hub may not be running when fetch fails", () => {
+  const url = "http://127.0.0.1:59999";
+  const result = spawnSync("node", ["build/index.js", "--url", url, "get-info"], {
+    encoding: "utf-8",
+    cwd: process.cwd(),
+  });
+  const output = result.stdout + result.stderr;
+  expect(output).toContain(`are you sure the hub is running on ${url}?`);
+});


### PR DESCRIPTION
## Summary

Fixes #9. When the hub isn't running or the URL is incorrect, the CLI previously surfaced only a bare `fetch failed` with no indication of the cause.

This catches that specific network error (`TypeError` with message `"fetch failed"`, thrown by Node's `fetch` when it can't reach the server) and appends a hint:

```
fetch failed - are you sure the hub is running on http://127.0.0.1:59999?
```

The check is scoped narrowly: any other error (e.g. `Invalid URL`) is rethrown unchanged, so the hint never shows unexpectedly.

## Changes

- `src/client.ts`: wrap the `fetch` call in a private helper that adds the hint only for the connection-level `fetch failed` error.
- `src/test/hub.test.ts`: add a test asserting the hint appears when the target URL is unreachable.

## Testing

- `tsc` passes
- Unit tests pass (2/2)
- Manual: dead URL → hint shown; malformed URL → `Invalid URL` (no hint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)