### PR TITLE
feat(list-apps): add --name filter to look up a single app's balance

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ You can also pass the token via environment variable instead of `--save`:
 
 ```bash
 export HUB_TOKEN="eyJ..."
-npx @getalby/hub-cli balances
+npx @getalby/hub-cli get-balances
 ```
 
 **Token storage locations:**
@@ -259,7 +259,10 @@ npx @getalby/hub-cli lookup-transaction <paymentHash>
 
 ```bash
 # List NWC app connections
-npx @getalby/hub-cli apps
+npx @getalby/hub-cli list-apps
+
+# Look up a single app by name (prefix match) — the response includes its balance
+npx @getalby/hub-cli list-apps --name "My App"
 
 # Create a new NWC connection
 npx @getalby/hub-cli create-app --name "My App"
@@ -341,10 +344,10 @@ npx @getalby/hub-cli create-app --name "Isolated App" --isolated --unlock-passwo
 
 ### NWC Apps
 
-| Command      | Description                 | Required Options |
-| ------------ | --------------------------- | ---------------- |
-| `apps`       | List NWC app connections    | —                |
-| `create-app` | Create a new NWC connection | `--name`         |
+| Command      | Description                                          | Required Options |
+| ------------ | --------------------------------------------------- | ---------------- |
+| `list-apps`  | List NWC app connections (filter with `--name`)     | —                |
+| `create-app` | Create a new NWC connection                         | `--name`         |
 
 ## Output
 

--- a/src/commands/list-apps.ts
+++ b/src/commands/list-apps.ts
@@ -6,10 +6,21 @@ export function registerListAppsCommand(program: Command): void {
   program
     .command("list-apps")
     .description("List NWC app connections")
-    .action(async () => {
+    .option(
+      "--name <name>",
+      "Filter apps by name (prefix match). Use this to look up a single app's balance.",
+    )
+    .action(async (opts: { name?: string }) => {
       await handleError(async () => {
         const client = getClient(program);
-        const result = await client.get<ListAppsResponse>("/api/apps");
+        const params = new URLSearchParams();
+        if (opts.name) {
+          params.set("filters", JSON.stringify({ name: opts.name }));
+        }
+        const query = params.toString();
+        const result = await client.get<ListAppsResponse>(
+          `/api/apps${query ? `?${query}` : ""}`,
+        );
         output(result);
       });
     });

--- a/src/test/hub.test.ts
+++ b/src/test/hub.test.ts
@@ -12,4 +12,14 @@ test("shows help when run with no arguments", () => {
   expect(output).toContain("info");
   expect(output).toContain("balances");
   expect(output).toContain("channels");
+  expect(output).toContain("list-apps");
+});
+
+test("list-apps help documents the --name filter", () => {
+  const result = spawnSync("node", ["build/index.js", "list-apps", "--help"], {
+    encoding: "utf-8",
+    cwd: process.cwd(),
+  });
+  const output = result.stdout + result.stderr;
+  expect(output).toContain("--name");
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -147,7 +147,12 @@ export interface App {
   budgetUsage: number;
   budgetRenewal: string;
   isolated: boolean;
+  /** @deprecated millisatoshi balance — use balanceSat. Isolated apps and sub-wallets only; 0 for shared-balance apps. */
   balance: number;
+  /** App balance in satoshis. Non-zero only for isolated apps and sub-wallets; distinct from the hub wallet balance. */
+  balanceSat: number;
+  /** App balance in millisatoshis. */
+  balanceMsat: number;
 }
 
 export interface ListAppsResponse {


### PR DESCRIPTION
## Summary

Adds a `--name` filter to `list-apps` so a single app can be looked up by name — and, crucially, so its **balance** is returned directly. This is the CLI half of getAlby/hub-skill#27 ("Asking about an app's balance went wrong"): there was no way to fetch a particular app by name, which is needed to report the balance of an **isolated app** or **sub-wallet** (distinct from the hub wallet balance).

## Changes

- **`list-apps --name <name>`** — sends the Hub API's name filter (`GET /api/apps?filters={"name":...}`, prefix match `ILIKE name%`). The matching app(s) come back in `apps[]` with their balances.
- **`App` type** — added `balanceSat` / `balanceMsat` (the API already returns these) and marked the legacy millisatoshi `balance` field `@deprecated`. The app balance is non-zero only for isolated apps and sub-wallets.
- **README** — documented `list-apps --name`, fixed the table, and corrected stale `apps`/`balances` command names to `list-apps`/`get-balances`.
- **Tests** — `list-apps` now asserted in the no-args help, plus a new test that `list-apps --help` documents `--name`.

## Notes on sub-wallets

App balance is exactly the isolated balance surfaced for sub-wallets (see getAlby/hub-cli#18). `--name` lets a caller resolve `"<name>" → balanceSat` in one call.

## Verification

- `tsc` clean, Prettier clean
- Unit tests pass (incl. the new `--name` test)
- `list-apps --help` renders the flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)