### PR TITLE
feat: custom node commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,23 @@ npx @getalby/hub-cli connect-alby-account
 npx @getalby/hub-cli connect-alby-account --code YOUR_AUTH_CODE
 ```
 
+### Custom Node Commands
+
+Custom node (debug) commands are backend-specific. Use `list-custom-node-commands` to
+discover what the active backend exposes, then run one with `execute-custom-node-command`.
+
+```bash
+# List the custom node commands the active backend supports
+npx @getalby/hub-cli list-custom-node-commands
+
+# Execute a command (pass the full command line as one quoted string).
+# Example (Bark): dump balance breakdown, VTXOs and pending receives
+npx @getalby/hub-cli execute-custom-node-command "debug"
+
+# Example (LDK): pay a BOLT-12 offer (testing only)
+npx @getalby/hub-cli execute-custom-node-command "pay_bolt12_offer --offer lno... --amount 1000"
+```
+
 ### Payments
 
 ```bash
@@ -318,21 +335,28 @@ npx @getalby/hub-cli create-sub-wallet --name "Alice"
 
 ### Node Management
 
-| Command           | Description                                         | Required Options                                                      |
-| ----------------- | --------------------------------------------------- | --------------------------------------------------------------------- |
-| `stop`                   | Stop the Lightning node (HTTP server keeps running)  | —                                                                    |
-| `sync`                   | Trigger a wallet sync                                | —                                                                    |
-| `backup`                 | Export wallet recovery phrase to a file              | `--password`                                                         |
-| `change-password`        | Change the hub unlock password                       | `--current-password`, `--confirm-current-password`, `--new-password` |
-| `connect-alby-account`   | Connect your Alby account (returns auth URL or confirms connection) | `--code` (optional, step 2)                         |
+| Command                | Description                                                         | Required Options                                                     |
+| ---------------------- | ------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| `stop`                 | Stop the Lightning node (HTTP server keeps running)                 | —                                                                    |
+| `sync`                 | Trigger a wallet sync                                               | —                                                                    |
+| `backup`               | Export wallet recovery phrase to a file                             | `--password`                                                         |
+| `change-password`      | Change the hub unlock password                                      | `--current-password`, `--confirm-current-password`, `--new-password` |
+| `connect-alby-account` | Connect your Alby account (returns auth URL or confirms connection) | `--code` (optional, step 2)                                          |
+
+### Debug Tools
+
+| Command                       | Description                                              | Required Options       |
+| ----------------------------- | -------------------------------------------------------- | ---------------------- |
+| `list-custom-node-commands`   | List custom node (debug) commands for the active backend | —                      |
+| `execute-custom-node-command` | Execute a custom node (debug) command                    | `<command>` (argument) |
 
 ### Payments
 
-| Command                   | Description                      | Required Options              |
-| ------------------------- | -------------------------------- | ----------------------------- |
-| `pay-invoice`             | Pay a BOLT11 invoice             | `<invoice>` (argument)        |
-| `make-invoice`            | Create a BOLT11 invoice          | `--amount`                    |
-| `make-offer`              | Create a BOLT-12 offer           | —                             |
+| Command        | Description             | Required Options       |
+| -------------- | ----------------------- | ---------------------- |
+| `pay-invoice`  | Pay a BOLT11 invoice    | `<invoice>` (argument) |
+| `make-invoice` | Create a BOLT11 invoice | `--amount`             |
+| `make-offer`   | Create a BOLT-12 offer  | —                      |
 
 ### Transactions
 
@@ -343,11 +367,11 @@ npx @getalby/hub-cli create-sub-wallet --name "Alice"
 
 ### NWC Apps
 
-| Command             | Description                                      | Required Options |
-| ------------------- | ------------------------------------------------ | ---------------- |
-| `list-apps`         | List NWC app connections (filter with `--name`)  | —                |
-| `create-app`        | Create a new NWC connection                      | `--name`         |
-| `create-sub-wallet` | Create a sub-wallet (isolated app with balance)  | `--name`         |
+| Command             | Description                                     | Required Options |
+| ------------------- | ----------------------------------------------- | ---------------- |
+| `list-apps`         | List NWC app connections (filter with `--name`) | —                |
+| `create-app`        | Create a new NWC connection                     | `--name`         |
+| `create-sub-wallet` | Create a sub-wallet (isolated app with balance) | `--name`         |
 
 ## Output
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@getalby/hub-cli",
   "description": "CLI for managing Alby Hub - a self-custodial Lightning node",
   "repository": "https://github.com/getAlby/hub-cli.git",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "main": "build/index.js",
   "bin": {

--- a/src/commands/execute-custom-node-command.ts
+++ b/src/commands/execute-custom-node-command.ts
@@ -1,0 +1,19 @@
+import { Command } from "commander";
+import { getClient, handleError, output } from "../utils.js";
+
+export function registerExecuteCustomNodeCommandCommand(
+  program: Command,
+): void {
+  program
+    .command("execute-custom-node-command <command>")
+    .description(
+      'Execute a custom node (debug) command. Pass the full command line as a single quoted string, e.g. "debug" or "pay_bolt12_offer --offer lno... --amount 1000". Run list-custom-node-commands to see available commands and their arguments. DO NOT execute without human approval, some commands may have side effects and are for testing only.',
+    )
+    .action(async (command: string) => {
+      await handleError(async () => {
+        const client = getClient(program);
+        const result = await client.post<unknown>("/api/command", { command });
+        output(result);
+      });
+    });
+}

--- a/src/commands/list-custom-node-commands.ts
+++ b/src/commands/list-custom-node-commands.ts
@@ -1,0 +1,19 @@
+import { Command } from "commander";
+import { CustomNodeCommandsResponse } from "../types.js";
+import { getClient, handleError, output } from "../utils.js";
+
+export function registerListCustomNodeCommandsCommand(program: Command): void {
+  program
+    .command("list-custom-node-commands")
+    .description(
+      "List custom node (debug) commands supported by the active backend, with their arguments",
+    )
+    .action(async () => {
+      await handleError(async () => {
+        const client = getClient(program);
+        const result =
+          await client.get<CustomNodeCommandsResponse>("/api/commands");
+        output(result);
+      });
+    });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,13 +31,15 @@ import { registerSyncCommand } from "./commands/sync.js";
 import { registerBackupMnemonicCommand } from "./commands/backup-mnemonic.js";
 import { registerChangePasswordCommand } from "./commands/change-password.js";
 import { registerConnectAlbyAccountCommand } from "./commands/connect-alby-account.js";
+import { registerListCustomNodeCommandsCommand } from "./commands/list-custom-node-commands.js";
+import { registerExecuteCustomNodeCommandCommand } from "./commands/execute-custom-node-command.js";
 
 const program = new Command();
 
 program
   .name("hub-cli")
   .description("CLI for managing Alby Hub - a self-custodial Lightning node")
-  .version("0.5.0")
+  .version("0.6.0")
   .option(
     "-u, --url <url>",
     "Hub URL",
@@ -75,5 +77,7 @@ registerSyncCommand(program);
 registerBackupMnemonicCommand(program);
 registerChangePasswordCommand(program);
 registerConnectAlbyAccountCommand(program);
+registerListCustomNodeCommandsCommand(program);
+registerExecuteCustomNodeCommandCommand(program);
 
 program.parse();

--- a/src/test/e2e/custom-node-commands.e2e.test.ts
+++ b/src/test/e2e/custom-node-commands.e2e.test.ts
@@ -1,0 +1,77 @@
+import { test, expect, beforeAll, afterAll } from "vitest";
+import type { ChildProcess } from "node:child_process";
+import {
+  TEST_PASSWORD,
+  spawnHub,
+  runCommand,
+  waitForInfo,
+  killHub,
+} from "./helpers";
+import type { CustomNodeCommandsResponse } from "../../types.js";
+
+const HUB_PORT = 18097;
+const HUB_URL = `http://localhost:${HUB_PORT}`;
+
+let hubProcess: ChildProcess;
+let token: string;
+
+beforeAll(async () => {
+  ({ hubProcess } = await spawnHub(HUB_PORT, "hub-cli-e2e-nodecommands-"));
+
+  const setup = runCommand([
+    "--url",
+    HUB_URL,
+    "setup",
+    "--password",
+    TEST_PASSWORD,
+    "--backend",
+    "LDK",
+  ]);
+  if (setup.status !== 0) throw new Error(`setup failed: ${setup.stderr}`);
+
+  const start = runCommand([
+    "--url",
+    HUB_URL,
+    "start",
+    "--password",
+    TEST_PASSWORD,
+  ]);
+  if (start.status !== 0) throw new Error(`start failed: ${start.stderr}`);
+  token = JSON.parse(start.stdout).token;
+
+  await waitForInfo(HUB_URL, (i) => i.running);
+}, 120_000);
+
+afterAll(async () => {
+  if (hubProcess) await killHub(hubProcess);
+});
+
+test("list-custom-node-commands returns the backend's custom commands", () => {
+  const result = runCommand([
+    "--url",
+    HUB_URL,
+    "--token",
+    token,
+    "list-custom-node-commands",
+  ]);
+  expect(result.status).toBe(0);
+  const response = JSON.parse(result.stdout) as CustomNodeCommandsResponse;
+  expect(Array.isArray(response.commands)).toBe(true);
+  // LDK exposes export_pathfinding_scores among its debug commands
+  const names = response.commands.map((c) => c.name);
+  expect(names).toContain("export_pathfinding_scores");
+});
+
+test("execute-custom-node-command runs a command on the backend", () => {
+  const result = runCommand([
+    "--url",
+    HUB_URL,
+    "--token",
+    token,
+    "execute-custom-node-command",
+    "export_pathfinding_scores",
+  ]);
+  expect(result.status).toBe(0);
+  // command output is backend-defined; just assert we got valid JSON back
+  expect(() => JSON.parse(result.stdout)).not.toThrow();
+});

--- a/src/test/e2e/custom-node-commands.e2e.test.ts
+++ b/src/test/e2e/custom-node-commands.e2e.test.ts
@@ -63,15 +63,19 @@ test("list-custom-node-commands returns the backend's custom commands", () => {
 });
 
 test("execute-custom-node-command runs a command on the backend", () => {
+  // list_channel_monitor_sizes is safe to run on a fresh node: it returns an
+  // empty array when there are no channels. (export_pathfinding_scores errors
+  // until the node has built up a network graph, so it is not used here.)
   const result = runCommand([
     "--url",
     HUB_URL,
     "--token",
     token,
     "execute-custom-node-command",
-    "export_pathfinding_scores",
+    "list_channel_monitor_sizes",
   ]);
   expect(result.status).toBe(0);
-  // command output is backend-defined; just assert we got valid JSON back
-  expect(() => JSON.parse(result.stdout)).not.toThrow();
+  // command output is backend-defined; list_channel_monitor_sizes returns an
+  // array of per-channel monitor sizes (empty on a channel-less node)
+  expect(Array.isArray(JSON.parse(result.stdout))).toBe(true);
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -210,3 +210,18 @@ export interface HealthAlarm {
 export interface HealthResponse {
   alarms?: HealthAlarm[];
 }
+
+export interface CustomNodeCommandArgDef {
+  name: string;
+  description: string;
+}
+
+export interface CustomNodeCommandDef {
+  name: string;
+  description: string;
+  args: CustomNodeCommandArgDef[];
+}
+
+export interface CustomNodeCommandsResponse {
+  commands: CustomNodeCommandDef[];
+}


### PR DESCRIPTION
Allows the agent to fetch LDK or Bark-specific info.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `list-custom-node-commands` command to discover available backend debug commands
  * Added `execute-custom-node-command` command to run custom backend commands

* **Documentation**
  * Updated README with "Custom Node Commands" section explaining discovery and execution

* **Tests**
  * Added end-to-end test suite for custom node commands functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->